### PR TITLE
スケジュールを時系列順に出力

### DIFF
--- a/src/main/java/oit/is/team7/schedule/model/GroupScheduleMapper.java
+++ b/src/main/java/oit/is/team7/schedule/model/GroupScheduleMapper.java
@@ -12,12 +12,12 @@ import org.apache.ibatis.annotations.Update;
 public interface GroupScheduleMapper {
 
   /**
-   * groupidからscheduleidを取得する
+   * groupidからscheduleのリストを日付が若い順かつ同日なら開始時刻が早い順かつどちらも同じならスケジュールID順に取得する
    *
    * @param groupid int グループID
-   * @return ArrayList<Integer> scheduleidのリスト
+   * @return ArrayList<Integer> GroupScheduleのリスト
    */
-  @Select("SELECT * FROM groupSchedule WHERE GROUPID = #{groupid}")
+  @Select("SELECT * FROM groupSchedule WHERE GROUPID = #{groupid} ORDER BY hizuke, kaisi, scheduleid")
   ArrayList<GroupSchedule> selectgroupScheduleByGroupid(int groupid);
 
     /**
@@ -31,6 +31,7 @@ public interface GroupScheduleMapper {
 
   /**
    * scheduleidからGroupScheduleを修正する
+   * @param scheduleid int スケジュールid
    * @param hizuke  String 予定の日付
    * @param kaisi   String 予定の開始時刻
    * @param owari   String 予定の終了時刻


### PR DESCRIPTION
とりあえず、GroupScheduleMapperがgroupidからArrayListで出力するやつの、出力順を時系列に合わせてみました。h2-consoleでSQL文的には問題が無いのを確認しています。contoroller的に問題があれば戻します。

それと、インサート文もなんか全部更新するようになってたので、動作チェックはしました。