### PR TITLE
予定の削除と、user3,4の実装

### DIFF
--- a/src/main/java/oit/is/team7/schedule/controller/ScheduleController.java
+++ b/src/main/java/oit/is/team7/schedule/controller/ScheduleController.java
@@ -120,6 +120,27 @@ public class ScheduleController {
     return "content.html";
   }
 
+  @GetMapping("/delete")
+  public String delete(@RequestParam Integer id ,ModelMap model) {
+    boolean delete_flag = true;
+    GroupSchedule groupSchedule = groupschedulemapper.getgroupScheduleByScheduleid(id);
+    model.addAttribute("delete_flag", delete_flag);
+    model.addAttribute("groupSchedule", groupSchedule);
+    return "content.html";
+  }
+
+  @GetMapping("/deleteYes")
+  public String deleteYes(@RequestParam Integer id, @RequestParam Integer gid,ModelMap model) {
+    groupschedulemapper.DeleteGroupScheduleByScheduleId(id);
+    //calendar(gid, model);
+    ArrayList<GroupSchedule> groupSchedules = groupschedulemapper.selectgroupScheduleByGroupid(gid);
+
+    model.addAttribute("groupSchedules", groupSchedules);
+    model.addAttribute("groupid", gid);
+
+    return "calendar.html";
+  }
+
   @GetMapping("/calendar/update")
   public SseEmitter asyncCalendar(@RequestParam Integer id) {
 

--- a/src/main/java/oit/is/team7/schedule/model/GroupScheduleMapper.java
+++ b/src/main/java/oit/is/team7/schedule/model/GroupScheduleMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
+import org.apache.ibatis.annotations.Delete;
 
 @Mapper
 public interface GroupScheduleMapper {
@@ -59,5 +60,14 @@ public interface GroupScheduleMapper {
   @Insert("INSERT INTO groupSchedule (hizuke, kaisi, owari, groupid,title,content) VALUES (#{hizuke}, #{kaisi}, #{owari}, #{groupid},#{title},#{content});")
   @Options(useGeneratedKeys = true, keyColumn = "scheduleid")
   void insertGroupSchedule(String hizuke, String kaisi, String owari, int groupid, String title, String content);
+
+  /**
+   * groupScheduleのDelete文
+   *
+   * @param scheduleid int スケジュールID
+   * @return void
+   */
+  @Delete("DELETE FROM GroupSchedule WHERE ScheduleId = #{ScheduleId};")
+  void DeleteGroupScheduleByScheduleId(int ScheduleId);
 
 }

--- a/src/main/java/oit/is/team7/schedule/security/ScheduleAuthConfiguration.java
+++ b/src/main/java/oit/is/team7/schedule/security/ScheduleAuthConfiguration.java
@@ -38,11 +38,11 @@ public class ScheduleAuthConfiguration {
         .password("{bcrypt}$2y$10$DPZvoBEzZrecXwgAhq/69OoHbWam2Kq0taE9gXsEHJ4q9yRzGtvHO")
         .roles("USER").build();
     UserDetails user2 = User.withUsername("user2")
-        .password("{bcrypt}$2y$10$DPZvoBEzZrecXwgAhq/69OoHbWam2Kq0taE9gXsEHJ4q9yRzGtvHO").roles("USER").build();
-    UserDetails user3 = User.withUsername("ほんだ")
-        .password("{bcrypt}$2y$10$AQOcWiX2.MA6Czw4p4OYzuw25.7Vcmgav6gaQDKFsu8opn8BdrjDG").roles("USER").build();
-    UserDetails user4 = User.withUsername("いがき")
-        .password("{bcrypt}$2y$10$AQOcWiX2.MA6Czw4p4OYzuw25.7Vcmgav6gaQDKFsu8opn8BdrjDG").roles("USER").build();
+        .password("{bcrypt}$2y$10$SbWZIjsMBTtJ6SaG34GxauRrl7rD7YBKDQihnvmwaoEU/Q0kYy4ae").roles("USER").build();
+    UserDetails user3 = User.withUsername("user3")
+        .password("{bcrypt}$2y$10$bifSQsD6CxLgDfbvmdJi5.MArojBdtczVtBMqwr6F3PaCFoXO7s26").roles("USER").build();
+    UserDetails user4 = User.withUsername("user4")
+        .password("{bcrypt}$2y$10$qBTq8Ku0XpEA.MlHdbgMz.AocTZOc53q1TMb1mUP.vmK73vgkPTkO").roles("USER").build();
 
     return new InMemoryUserDetailsManager(user1, user2, user3, user4);
   }

--- a/src/main/resources/templates/content.html
+++ b/src/main/resources/templates/content.html
@@ -50,6 +50,15 @@
       <br><br>
     </form>
   </div>
+  <a th:href="@{/delete(id=${groupSchedule.scheduleid})}">
+    削除
+  </a><br><br>
+  <div th:if="${delete_flag}">
+    <p>本当に削除します、よろしいですね？</p>
+    <a th:href="@{/deleteYes(id=${groupSchedule.scheduleid},gid=${groupSchedule.groupid})}">
+      はい
+    </a><br><br>
+  </div>
   <a th:href="@{/calendar(id=${groupSchedule.groupid})}">
     もどる
   </a>


### PR DESCRIPTION
予定の詳細欄で予定の削除機能を追加(非同期ではない)
それと、セキュリティの認可処理関連で、user1,user2,user3,user4の四つのアカウントでログインできるようにした。
パスワードはどれもisdev、他グループの予定やらを操作して、現状のところおかしな所はなさそうです。